### PR TITLE
Implement, document, and test 'amendOrphan'

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,30 @@ Break a word between any two letters when the word is longer than the specified 
 wrap(str, {cut: true});
 ```
 
+### options.amendOrphan
+
+Type: `Boolean`
+
+Default: `false`
+
+Amends the last line in the case it has one word.  Only occurs when:
+ - there's more than one line,
+ - the second to last line has more than one word
+ - the amended line would not pass [width](#options.width)
+ - [options.cut](#options.cut) is not true.
+
+**Example:**
+
+```js
+//                  1
+//         12345678901234567
+var str = 'This is an orphan';
+wrap(str, {width: 10, amendOrphan: true});
+// returns
+//  This is
+//  an orphan
+```
+
 ## Related projects
 
 * [common-words](https://www.npmjs.com/package/common-words): Updated list (JSON) of the 100 most common words in the English language. Useful for… [more](https://www.npmjs.com/package/common-words) | [homepage](https://github.com/jonschlinkert/common-words)

--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ Default: `false`
 Amends the last line in the case it has one word.  Only occurs when:
  - there's more than one line,
  - the second to last line has more than one word
- - the amended line would not pass [width](#options.width)
- - [options.cut](#options.cut) is not true.
+ - the amended line would not pass [width](#options.width).
 
 **Example:**
 

--- a/index.js
+++ b/index.js
@@ -58,19 +58,19 @@ module.exports = function(str, options) {
 };
 
 function handleOrphan(lines, width, wasCutMidWord) {
-  var len = lines.length
-    , lastLine = lines[len - 1]
+  var len = lines.length;
+  if (len <= 1) return lines;
+
+  var lastLine = lines[len - 1]
     , secondToLastLine = lines[len - 2]
     , orphanAdopter = getLastWord(secondToLastLine)
     , amendedLastLine = orphanAdopter + (wasCutMidWord ? '' : ' ') + lastLine;
 
   // we only want to handle orphans when:
-  //  - there's more than one line,
   //  - the second to last line has more than one word
   //  - the last line has only a single word
   //  - the amended line would not pass width
-  var shouldHandleOrphan = len > 1
-    && secondToLastLine.trim()
+  var shouldHandleOrphan = secondToLastLine.trim()
       .split(WS)
       .length > 1
     &&  lastLine.trim()

--- a/index.js
+++ b/index.js
@@ -8,6 +8,9 @@
  * @attribution
  */
 
+// WS: word separator
+var WS = /\s+/;
+
 module.exports = function(str, options) {
   options = options || {};
   if (str == null) {
@@ -35,7 +38,7 @@ module.exports = function(str, options) {
     re = new RegExp('.{1,' + width + '}', 'g');
     // if the character right before the last line is not whitespace, then the
     //   line was cut mid-word.
-    wasCutMidWord = !str.charAt(str.length - (str.length % width) - 1).match(/\s/);
+    wasCutMidWord = !str.charAt(str.length - (str.length % width) - 1).match(WS);
   }
 
   var lines = str.match(re) || [];
@@ -56,8 +59,6 @@ module.exports = function(str, options) {
 
 function handleOrphan(lines, width, wasCutMidWord) {
   var len = lines.length
-    // WS: word separator
-    , WS = /\s+/
     , lastLine = lines[len - 1]
     , secondToLastLine = lines[len - 2]
     , orphanAdopter = getLastWord(secondToLastLine)

--- a/test.js
+++ b/test.js
@@ -61,5 +61,11 @@ describe('wrap', function () {
 
     // don't handle if the amended line length would be greater than width
     assert.equal(wrap("Don't amend orphan", {width:11, amendOrphan:true}), "  Don't amend \n  orphan");
+
+    // handle when cut = true
+    assert.equal(wrap('What a Supercalif', {width:10, amendOrphan:true, cut:true}), '  What a \n  Supercalif');
+
+    // except when the amended cut line has length > width
+    assert.equal(wrap('What a Supercalif', {width:9, amendOrphan:true, cut:true}), '  What a Su\n  percalif');
   });
 });

--- a/test.js
+++ b/test.js
@@ -49,6 +49,17 @@ describe('wrap', function () {
 
   it('should cut long words', function() {
     assert.equal(wrap('Supercalifragilisticexpialidocious and Supercalifragilisticexpialidocious', {width:24, cut:true}), '  Supercalifragilisticexpi\n  alidocious and Supercali\n  fragilisticexpialidociou\n  s');
-  })
+  });
 
+  it('should handle orphans', function() {
+    assert.equal(wrap('This is an orphan', {width:10, amendOrphan:true}), '  This is \n  an orphan');
+
+    // handle more than a single whitespace character between orphan and orphan adopter to keep existing functionality
+    assert.equal(wrap('This is \t  an orphan', {width:10, amendOrphan:true}), '  This is \t  \n  an orphan');
+
+    assert.equal(wrap('Nope, no orphan here', {width:11, amendOrphan:true}), '  Nope, no \n  orphan here');
+
+    // don't handle if the amended line length would be greater than width
+    assert.equal(wrap("Don't amend orphan", {width:11, amendOrphan:true}), "  Don't amend \n  orphan");
+  });
 });


### PR DESCRIPTION
Should be well commented/documented.  I hadn't realized `_.words` filters out non alphanumeric characters by default, so the definition of 'word' is simplified to be `/\s+/` delimited.

I also tried to keep within well-supported string and array functions.  If I added any which reasonably older browsers don't support, please yell.
