### PR TITLE
Include TypeScript type definitions in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "license": "MIT",
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
The npm package doesn't currently include them. This should add it.