### PR TITLE
Not inserting additional newlines when there is leading whitespace in a multiline string.

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,11 +43,19 @@ module.exports = function(str, options) {
 
   var re = new RegExp(regexString, 'g');
   var lines = str.match(re) || [];
+  // The regex split will take whitespace from the start of next line,
+  // and put it on the end of the previous one. Need to move that back.
+  var extraWhitespace = '';
   var result = indent + lines.map(function(line) {
-    if (line.slice(-1) === '\n') {
-      line = line.slice(0, line.length - 1);
+    var fullLine = extraWhitespace + line;
+    var match = line.match(/^(.+)\n([^\S\n]*)$/s);
+    if (match) {
+      fullLine = extraWhitespace + match[1];
+      extraWhitespace = match[2];
+    } else {
+      extraWhitespace = '';
     }
-    return escape(line);
+    return escape(fullLine);
   }).join(newline);
 
   if (options.trim === true) {

--- a/test.js
+++ b/test.js
@@ -66,4 +66,18 @@ describe('wrap', function () {
       '  Supercalifragilistic\u200B\n  expialidocious'
     );
   });
+
+  it('should preserve whitespace after a newline', function() {
+    assert.equal(
+      wrap('Highlights:\n First\n Second\n Third', { indent: '' }),
+      'Highlights:\n First\n Second\n Third'
+    );
+  });
+
+  it('should preserve whitespace after a newline and handle indents appropriately', function() {
+    assert.equal(
+      wrap('Highlights:\n First\n Second\n Third', { indent: '*' }),
+      '*Highlights:\n* First\n* Second\n* Third'
+    );
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/jonschlinkert/word-wrap/issues/27

When `cut` is false and the text to wrap contains newlines, the split slurps up whitespace following those newlines. This was stopping the newline character being removed (as it was not at the end of the string) and caused an additional newline to be added.

Also, the whitespace that should have been at the start of the next line had no effect, as it ended up on the additional line that was created.

Checking for trailing whitespace following a newline, moving it to the start of the next line, and removing the newline character fixes the test case mentioned on the issue.

